### PR TITLE
Add profile management features to API

### DIFF
--- a/app/Http/Controllers/Api/V1/Auth/LogoutController.php
+++ b/app/Http/Controllers/Api/V1/Auth/LogoutController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Auth;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class LogoutController extends Controller
+{
+    public function __invoke(Request $request)
+    {
+        $request->user()->currentAccessToken()->delete();
+
+        return response()->noContent();
+    }
+}

--- a/app/Http/Controllers/Api/V1/Auth/PasswordUpdateController.php
+++ b/app/Http/Controllers/Api/V1/Auth/PasswordUpdateController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Auth;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\Rules\Password;
+
+class PasswordUpdateController extends Controller
+{
+    public function __invoke(Request $request)
+    {
+        $request->validate([
+            'current_password' => ['required', 'current_password'],
+            'password'         => ['required', 'confirmed', Password::defaults()],
+        ]);
+
+        auth()->user()->update([
+            'password' => Hash::make($request->input('password')),
+        ]);
+
+        return response()->json([
+            'message' => 'Your password has been updated.',
+        ], Response::HTTP_ACCEPTED);
+    }
+}

--- a/app/Http/Controllers/Api/V1/Auth/ProfileController.php
+++ b/app/Http/Controllers/Api/V1/Auth/ProfileController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Auth;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Validation\Rule;
+
+class ProfileController extends Controller
+{
+    public function show(Request $request)
+    {
+        return response()->json($request->user()->only('name', 'email'));
+    }
+
+    public function update(Request $request)
+    {
+        $validatedData = $request->validate([
+            'name' => ['required', 'string'],
+            'email' => ['required', 'email', Rule::unique('users')->ignore(auth()->user())],
+        ]);
+
+        auth()->user()->update($validatedData);
+
+        return response()->json($validatedData, Response::HTTP_ACCEPTED);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,10 +1,11 @@
 <?php
 
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
-use \App\Http\Controllers\Api\V1\Auth;
 use \App\Http\Controllers\Api\V1\Auth\RegisterController;
+use \App\Http\Controllers\Api\V1\Auth\ProfileController;
+use \App\Http\Controllers\Api\V1\Auth\PasswordUpdateController;
 use \App\Http\Controllers\Api\V1\Auth\LoginController;
+use \App\Http\Controllers\Api\V1\Auth\LogoutController;
 
 /*
 |--------------------------------------------------------------------------
@@ -17,8 +18,11 @@ use \App\Http\Controllers\Api\V1\Auth\LoginController;
 |
 */
 
-Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
-    return $request->user();
+Route::middleware('auth:sanctum')->group(function () {
+    Route::get('profile', [ProfileController::class, 'show']);
+    Route::put('profile', [ProfileController::class, 'update']);
+    Route::put('password', PasswordUpdateController::class);
+    Route::post('auth/logout', LogoutController::class);
 });
 Route::post('auth/register', RegisterController::class);
 Route::post('auth/login', LoginController::class);


### PR DESCRIPTION
This Pull Request (PR) introduces new features to our API that allow users to manage their profiles. Here's what's new:

- View Profile: Users can now view their own profile details, including their name and email.
- Update Profile: Users can edit their name and email in their profile.
- Change Password: Users have the option to change their password.
- Logout: Users can log out, effectively deleting their current access token.