### PR TITLE
Override 404 error message for Vehicle API

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -3,6 +3,7 @@
 namespace App\Exceptions;
 
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Throwable;
 
 class Handler extends ExceptionHandler
@@ -23,8 +24,12 @@ class Handler extends ExceptionHandler
      */
     public function register(): void
     {
-        $this->reportable(function (Throwable $e) {
-            //
+        $this->renderable(function (NotFoundHttpException $e, $request) {
+            if ($request->is('api/v1/vehicles/*')) {
+                return response()->json([
+                    'message' => 'Vehicle record not found.'
+                ], 404);
+            }
         });
     }
 }


### PR DESCRIPTION
This PR overrides the default 404 error message for the Vehicle API endpoints. Here are the key changes:

1. **Handler Exception**: The `Handler` class in the `Exceptions` directory has been updated to handle `NotFoundHttpException`. 

2. **Custom 404 Message**: When a `NotFoundHttpException` is thrown for any API endpoint under `api/v1/vehicles/*`, a custom JSON response is returned with a message 'Vehicle record not found.' and a 404 status code.

This change provides a more user-friendly and specific error message when a vehicle record is not found in the API. Please review these changes and let me know if any adjustments are needed.