### PR TITLE
Add API endpoint for retrieving parking zones

### DIFF
--- a/app/Http/Controllers/Api/V1/ZoneController.php
+++ b/app/Http/Controllers/Api/V1/ZoneController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\ZoneResource;
+use App\Models\Zone;
+
+class ZoneController extends Controller
+{
+    public function index()
+    {
+        return ZoneResource::collection(Zone::all());
+    }
+}

--- a/app/Http/Resources/ZoneResource.php
+++ b/app/Http/Resources/ZoneResource.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ZoneResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'price_per_hour' => $this->price_per_hour,
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,12 +1,13 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
-use \App\Http\Controllers\Api\V1\Auth\RegisterController;
-use \App\Http\Controllers\Api\V1\Auth\ProfileController;
-use \App\Http\Controllers\Api\V1\Auth\PasswordUpdateController;
-use \App\Http\Controllers\Api\V1\Auth\LoginController;
-use \App\Http\Controllers\Api\V1\Auth\LogoutController;
+use App\Http\Controllers\Api\V1\Auth\RegisterController;
+use App\Http\Controllers\Api\V1\Auth\ProfileController;
+use App\Http\Controllers\Api\V1\Auth\PasswordUpdateController;
+use App\Http\Controllers\Api\V1\Auth\LoginController;
+use App\Http\Controllers\Api\V1\Auth\LogoutController;
 use App\Http\Controllers\Api\V1\VehicleController;
+use App\Http\Controllers\Api\V1\ZoneController;
 
 /*
 |--------------------------------------------------------------------------
@@ -28,3 +29,5 @@ Route::middleware('auth:sanctum')->group(function () {
 });
 Route::post('auth/register', RegisterController::class);
 Route::post('auth/login', LoginController::class);
+
+Route::get('zones', [ZoneController::class, 'index']);


### PR DESCRIPTION
This PR adds a new API endpoint for retrieving parking zones. Here are the key changes:

1. **New Controller**: A new `ZoneController` has been created under `App\Http\Controllers\Api\V1`. This controller has an `index` method that retrieves all zones and returns them as a collection of `ZoneResource`.

2. **New Resource**: A new `ZoneResource` has been created under `App\Http\Resources`. This resource transforms a `Zone` model into an array, selecting only the `id`, `name`, and `price_per_hour` fields for output.

3. **New Route**: A new route has been added to `routes/api.php`. This route maps GET requests to `/api/v1/zones` to the `index` method of `ZoneController`.

This new endpoint will allow the application to retrieve a list of all parking zones, which can be used to display available zones to the user and allow them to select a zone to start parking. Please review these changes and let me know if any adjustments are needed.