### PR TITLE
Implement ParkingPriceService for parking price calculation

### DIFF
--- a/app/Http/Controllers/Api/V1/ParkingController.php
+++ b/app/Http/Controllers/Api/V1/ParkingController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api\V1;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\ParkingResource;
 use App\Models\Parking;
+use App\Services\ParkingPriceService;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 
@@ -42,6 +43,7 @@ class ParkingController extends Controller
     {
         $parking->update([
             'stop_time' => now(),
+            'total_price' => ParkingPriceService::calculatePrice($parking->zone_id, $parking->start_time),
         ]);
     
         return ParkingResource::make($parking);

--- a/app/Http/Resources/ParkingResource.php
+++ b/app/Http/Resources/ParkingResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Resources;
 
+use App\Services\ParkingPriceService;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
@@ -14,6 +15,12 @@ class ParkingResource extends JsonResource
      */
     public function toArray(Request $request): array
     {
+        $totalPrice = $this->total_price ?? ParkingPriceService::calculatePrice(
+            $this->zone_id,
+            $this->start_time,
+            $this->stop_time
+        );
+
         return [
             'id' => $this->id,
             'zone' => [
@@ -25,7 +32,7 @@ class ParkingResource extends JsonResource
             ],
             'start_time' => $this->start_time->toDateTimeString(),
             'stop_time' => $this->stop_time?->toDateTimeString(),
-            'total_price' => $this->total_price,
+            'total_price' => $totalPrice,
         ];
     }
 }

--- a/app/Services/ParkingPriceService.php
+++ b/app/Services/ParkingPriceService.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Zone;
+use Carbon\Carbon;
+
+class ParkingPriceService {
+
+    public static function calculatePrice(int $zone_id, string $startTime, string $stopTime = null): int
+    {
+        $start = new Carbon($startTime);
+        $stop = (!is_null($stopTime)) ? new Carbon($stopTime) : now();
+
+        $totalTimeByMinutes = $stop->diffInMinutes($start);
+
+        $priceByMinutes = Zone::find($zone_id)->price_per_hour / 60;
+
+        return ceil($totalTimeByMinutes * $priceByMinutes);
+    }
+
+}


### PR DESCRIPTION
This PR introduces a new service class, `ParkingPriceService`, specifically for calculating the price of parking.

- The `ParkingPriceService` has a static method `calculatePrice` which takes three parameters: `zone_id`, `startTime`, and `stopTime`. `startTime` and `stopTime` are used to calculate the total parking time in minutes. If `stopTime` is not provided, the current time is used.
- The method then retrieves the price per hour for the given `zone_id` from the `Zone` model, converts it to a price per minute, and multiplies it by the total parking time to get the total price. The result is rounded up to the nearest integer and returned.
- This service provides a centralized way to calculate parking prices, which can be used throughout the application wherever this calculation is needed.